### PR TITLE
Fix Seawide catalog download

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The tool works without external dependencies and stores configuration locally.
 
 ```bash
 python -m automation_tool
-``` 
-or run the script directly:
+```
+or run the entry point directly:
 ```bash
 python automation_tool/main.py
 ```

--- a/automation_tool/main.py
+++ b/automation_tool/main.py
@@ -1,6 +1,12 @@
 import logging
 import os
+import sys
 """Console entry point for the automation tool."""
+
+# Allow running the file directly by ensuring the parent directory is on
+# ``sys.path``. This mirrors ``python -m automation_tool`` behaviour.
+if __package__ is None:  # pragma: no cover - runtime convenience
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from automation_tool import (
     KeystoneSupplier,

--- a/automation_tool/seawide.py
+++ b/automation_tool/seawide.py
@@ -215,6 +215,7 @@ class SeawideSupplier(Supplier):
         user = self.get_credential('username')
         password = self.get_credential('password')
         port = int(self.get_credential('port', 21))
+        protocol = self.get_credential('protocol', 'ftps').lower()
         remote = self.get_credential('catalog_remote', 'catalog.csv')
         out_dir = self.get_credential('catalog_dir', '.')
         name = self.get_credential('catalog_name', 'seawide_catalog.csv')


### PR DESCRIPTION
## Summary
- fix missing `protocol` var in Seawide supplier catalog fetch
- enable running `automation_tool/main.py` directly

## Testing
- `python -m compileall -q .`
- `python inventory_processor.py --help`
- ran `python automation_tool/main.py` with input redirection (fails at EOF but imports correctly)


------
https://chatgpt.com/codex/tasks/task_e_6863cb3303a88329aabe606ecb78253d