### PR TITLE
Allow running main.py directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,71 @@
 # Ecommerce Inventory Tools
 
-This repository contains utilities for managing inventory data.
+This repository contains utilities for managing inventory data and simple supplier integrations.
+
+## Automation Tool
+
+`automation_tool` provides a console interface for managing supplier credentials and scheduling inventory updates.  Each supplier module contains logic to retrieve inventory using the stored credentials:
+
+* **Keystone** - uses the SOAP web service as the **primary** inventory tracking method via `GetInventoryUpdates` and automatically falls back to FTP when the SOAP call fails.
+* **CWR** - downloads the CSV feed and optionally merges a SKU mapping. A force full inventory option resets the timestamp to 1970.
+* **Seawide** - the **primary** inventory method uses the SOAP API (`GetInventoryFull` and `GetInventoryUpdates`) and falls back to FTP if the SOAP request fails.
+
+Keystone and Seawide support optional FTP credentials. In each supplier menu
+you'll see a **Set FTP Credentials** tab where you enter only `FTP User` and
+`FTP Password`. The host, port (`990`) and protocol (implicit FTPS) are fixed and
+not prompted. You can also specify a default `Remote Folder` and `Remote File`
+used when downloading inventory from FTP. Passive mode is enabled automatically
+for all connections. Use **Test Connection** to verify the FTP access. For SOAP
+access provide `account_number` and `security_key` via **Set Credential**. Seawide
+works the same way but uses an `api_key`.
+All credentials are stored locally until you change them.
+
+When selecting **Fetch Inventory Update via FTP** for Keystone or Seawide, you
+will be prompted for the remote file name if none is saved. The tool prints the
+percent complete while downloading (or the downloaded size if the server does
+not report file length).
+
+All suppliers now include utilities to test their connection and download a
+vendor catalog. Catalogs are stored under `automation_tool/data/catalogs` and can
+be managed from the menu (delete SKUs individually or via a delete file).
+
+The tool works without external dependencies and stores configuration locally.
+
+All inventory actions are logged to `automation.log`. When a SOAP or FTP request
+fails, the error message is printed to the console and recorded in the log so
+you can diagnose connection issues.
+If a SOAP request succeeds but returns no data, the response is checked for
+common fault messages. Errors like `*** You are not authorized to use this
+function ***` or `*** Illegal use of this web service !!! ***` will be shown in
+the console and saved to the log for easier debugging.
+
+### Running
+
+```bash
+python -m automation_tool
+``` 
+or run the script directly:
+```bash
+python automation_tool/main.py
+```
+
+From the menu select a supplier, add credentials (API keys, FTP details, etc.) and optionally schedule recurring inventory fetches.  Keystone, CWR and Seawide offer both update and full inventory downloads which can also be scheduled.
+For each supplier you may test the connection and schedule catalog downloads at intervals of **5 minutes**, **1 hour**, **1 day** or **1 week**. Catalog entries can later be removed from the "Manage Catalog" option.
 
 ## Inventory Processor
 
-`inventory_processor.py` automates downloading the CWR Distribution inventory feed, merging with a local SKU mapping file, cleaning the data, and exporting a CSV for Amazon or internal use.
+`inventory_processor.py` automates downloading the CWR Distribution inventory feed, merging with a local SKU mapping file, cleaning the data, and exporting a TSV file suitable for Amazon or internal use.
 
 ### Usage
 
-```
+```bash
 python inventory_processor.py \
   --base-url https://example.com/inventory \
   --since 1717900000 \
   --mapping mapping.csv \
-  --output final_inventory.csv
+  --output final_inventory.txt
 ```
 
-`--since` should be the UNIX timestamp representing the last update time. `--mapping` must be a CSV file with two columns: `cwr_sku` and `my_sku`.
+`--since` should be the UNIX timestamp representing the last update time. `--mapping` must be a CSV file with columns `sku` and `modified_sku`.
 
-The script uses only the Python standard library and can run in restricted environments without additional dependencies.
+Both scripts rely only on the Python standard library and run in restricted environments.

--- a/automation_tool/__init__.py
+++ b/automation_tool/__init__.py
@@ -1,0 +1,13 @@
+"""Automation tool package exports."""
+
+from .keystone import KeystoneSupplier
+from .cwr import CwrSupplier
+from .seawide import SeawideSupplier
+from .scheduler import RepeatedTimer
+
+__all__ = [
+    "KeystoneSupplier",
+    "CwrSupplier",
+    "SeawideSupplier",
+    "RepeatedTimer",
+]

--- a/automation_tool/__main__.py
+++ b/automation_tool/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for ``python -m automation_tool``."""
+
+from .main import main
+
+
+if __name__ == "__main__":
+    main()
+

--- a/automation_tool/base.py
+++ b/automation_tool/base.py
@@ -1,0 +1,101 @@
+import json
+import os
+import logging
+
+
+class SFTPWrapper:
+    """Minimal wrapper exposing FTP-style methods for paramiko clients."""
+
+    def __init__(self, client):
+        self._client = client
+
+    def size(self, path: str) -> int:
+        return self._client.stat(path).st_size
+
+    def retrbinary(self, cmd: str, callback) -> None:
+        path = cmd.split(" ", 1)[1]
+        with self._client.file(path, "rb") as f:
+            while True:
+                data = f.read(32768)
+                if not data:
+                    break
+                callback(data)
+
+    def quit(self) -> None:
+        self._client.close()
+
+
+class ImplicitFTP_TLS:
+    """Adapter for implicit FTPS that wraps the socket before login."""
+
+    def __init__(self, *args, **kwargs):
+        import ftplib
+        self._ftp = ftplib.FTP_TLS(*args, **kwargs)
+        self._host = None
+
+    def __getattr__(self, item):
+        return getattr(self._ftp, item)
+
+    def connect(self, host: str = "", port: int = 0, timeout: int | None = None):
+        self._host = host
+        return self._ftp.connect(host, port, timeout)
+
+    @property
+    def sock(self):
+        return self._ftp.sock
+
+    @sock.setter
+    def sock(self, value):
+        if value is not None:
+            import ssl
+            ctx = ssl.create_default_context()
+            if self._host:
+                value = ctx.wrap_socket(value, server_hostname=self._host)
+            else:
+                value = ctx.wrap_socket(value)
+        self._ftp.sock = value
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+os.makedirs(DATA_DIR, exist_ok=True)
+
+class Supplier:
+    """Generic supplier storing credentials and providing a fetch hook."""
+    def __init__(self, name: str, config_name: str):
+        self.name = name
+        self.config_path = os.path.join(DATA_DIR, config_name)
+        self.credentials = {}
+        self.load()
+
+    def load(self) -> None:
+        if os.path.exists(self.config_path):
+            with open(self.config_path, 'r') as f:
+                self.credentials = json.load(f)
+
+    def save(self) -> None:
+        with open(self.config_path, 'w') as f:
+            json.dump(self.credentials, f)
+
+    def set_credential(self, key: str, value: str) -> None:
+        self.credentials[key] = value
+        self.save()
+
+    def get_credential(self, key: str, default=None):
+        return self.credentials.get(key, default)
+
+    def fetch_inventory(self) -> None:
+        logging.info("Fetching inventory for %s", self.name)
+
+    def configure_credentials(self) -> None:
+        """Prompt for a single credential key/value."""
+        key = input("Credential name: ")
+        value = input("Value: ")
+        self.set_credential(key, value)
+
+    def test_connection(self) -> None:
+        """Placeholder connection test."""
+        logging.info("Testing connection for %s", self.name)
+        print("No connection test implemented")
+
+    def fetch_catalog(self) -> None:
+        """Placeholder catalog fetch."""
+        logging.info("Fetching catalog for %s", self.name)

--- a/automation_tool/catalog.py
+++ b/automation_tool/catalog.py
@@ -1,0 +1,62 @@
+import csv
+import os
+from .base import DATA_DIR
+
+CATALOG_DIR = os.path.join(DATA_DIR, 'catalogs')
+os.makedirs(CATALOG_DIR, exist_ok=True)
+
+
+def catalog_path(name: str) -> str:
+    return os.path.join(CATALOG_DIR, f"{name}.csv")
+
+
+def apply_mapping(rows: list, mapping_file: str) -> list:
+    """Apply a SKU mapping file if provided."""
+    if not mapping_file or not os.path.exists(mapping_file):
+        return rows
+    with open(mapping_file, newline='') as f:
+        mapping = {r['sku']: r['modified_sku'] for r in csv.DictReader(f)}
+    new_rows = []
+    for r in rows:
+        sku = r.get('SKU')
+        if sku in mapping:
+            r = r.copy()
+            r['SKU'] = mapping[sku]
+        new_rows.append(r)
+    return new_rows
+
+
+def save_rows(name: str, rows: list) -> None:
+    path = catalog_path(name)
+    if not rows:
+        open(path, 'w').close()
+        return
+    with open(path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+
+
+def load_rows(name: str) -> list:
+    path = catalog_path(name)
+    if not os.path.exists(path):
+        return []
+    with open(path, newline='') as f:
+        return list(csv.DictReader(f))
+
+
+def delete_sku(name: str, sku: str) -> None:
+    rows = [r for r in load_rows(name) if r.get('SKU') != sku]
+    save_rows(name, rows)
+
+
+def delete_from_file(name: str, delete_file: str) -> None:
+    rows = load_rows(name)
+    deletes = set()
+    with open(delete_file, newline='') as f:
+        for row in csv.DictReader(f):
+            if row.get('DELETE', '').strip().upper() == 'X':
+                deletes.add(row.get('SKU'))
+    rows = [r for r in rows if r.get('SKU') not in deletes]
+    save_rows(name, rows)

--- a/automation_tool/cwr.py
+++ b/automation_tool/cwr.py
@@ -1,0 +1,95 @@
+import logging
+import csv
+import os
+import urllib.request
+from datetime import datetime, timedelta
+from pathlib import Path
+from .base import Supplier
+from . import catalog
+from inventory_processor import (
+    download_inventory,
+    merge_mapping,
+    save_inventory,
+)
+
+class CwrSupplier(Supplier):
+    """CWR Distribution supplier implementation."""
+    def __init__(self):
+        super().__init__('CWR', 'cwr.json')
+
+    def fetch_inventory(self) -> None:
+        base_url = self.get_credential('base_url')
+        mapping_file = self.get_credential('mapping_file')
+        output = self.get_credential('output', 'cwr_inventory.txt')
+        if not base_url:
+            logging.warning('CWR base_url credential missing')
+            return
+
+        since = int((datetime.now() - timedelta(hours=10)).timestamp())
+        try:
+            rows = download_inventory(base_url, since)
+            if mapping_file:
+                rows = merge_mapping(rows, Path(mapping_file))
+            save_inventory(rows, Path(output))
+            logging.info('Saved CWR inventory to %s', output)
+        except Exception as exc:
+            logging.exception('Failed to fetch CWR inventory: %s', exc)
+
+    def fetch_inventory_full(self) -> None:
+        """Force download the entire inventory feed."""
+        base_url = self.get_credential('base_url')
+        mapping_file = self.get_credential('mapping_file')
+        output = self.get_credential('full_output', 'cwr_inventory_full.txt')
+        if not base_url:
+            logging.warning('CWR base_url credential missing')
+            return
+        try:
+            rows = download_inventory(base_url, 0)
+            if mapping_file:
+                rows = merge_mapping(rows, Path(mapping_file))
+            save_inventory(rows, Path(output))
+            logging.info('Saved CWR full inventory to %s', output)
+        except Exception as exc:
+            logging.exception('Failed to fetch CWR full inventory: %s', exc)
+
+    def test_connection(self) -> None:
+        base_url = self.get_credential('base_url')
+        if not base_url:
+            print('Missing base_url credential')
+            return
+        try:
+            with urllib.request.urlopen(base_url, timeout=10) as resp:
+                if resp.status == 200:
+                    print('Connection successful')
+                    logging.info('CWR connection successful')
+                else:
+                    print('Connection failed: status', resp.status)
+                    logging.warning('CWR connection failed status %s', resp.status)
+        except Exception as exc:
+            logging.exception('CWR connection failed: %s', exc)
+            print('Connection failed:', exc)
+
+    def fetch_catalog(self) -> None:
+        base_url = self.get_credential('base_url')
+        mapping_file = self.get_credential('mapping_file')
+        out_dir = self.get_credential('catalog_dir', '.')
+        name = self.get_credential('catalog_name', 'cwr_catalog.csv')
+        output = os.path.join(out_dir, name)
+        if not base_url:
+            logging.warning('CWR base_url credential missing')
+            return
+        os.makedirs(out_dir, exist_ok=True)
+        try:
+            rows = download_inventory(base_url, 0)
+            if mapping_file:
+                rows = merge_mapping(rows, Path(mapping_file))
+            catalog.save_rows(self.name, rows)
+            with open(output, 'w', newline='') as f:
+                writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+                writer.writeheader()
+                writer.writerows(rows)
+            logging.info('Saved CWR catalog to %s', output)
+            print('Catalog saved to', catalog.catalog_path(self.name))
+        except Exception as exc:
+            logging.exception('Failed to fetch CWR catalog: %s', exc)
+            print('Catalog download failed:', exc)

--- a/automation_tool/keystone.py
+++ b/automation_tool/keystone.py
@@ -1,0 +1,350 @@
+import logging
+import urllib.request
+import xml.etree.ElementTree as ET
+import csv
+import os
+from .base import Supplier, SFTPWrapper, ImplicitFTP_TLS
+from . import catalog
+
+# Fixed FTP connection details for Keystone
+HOST = "ftp.ekeystone.com"
+PORT = 990  # implicit FTPS
+
+
+def _parse_dataset(xml_data: bytes) -> list:
+    """Parse Keystone SOAP dataset XML into rows."""
+    try:
+        root = ET.fromstring(xml_data)
+    except ET.ParseError:
+        return []
+
+    diffgram = root.find('.//{urn:schemas-microsoft-com:xml-diffgram-v1}diffgram')
+    if diffgram is None:
+        return []
+    dataset = diffgram.find('NewDataSet')
+    if dataset is None:
+        return []
+    rows = []
+    for table in dataset.findall('Table'):
+        row = {child.tag: (child.text or '') for child in table}
+        rows.append(row)
+    return rows
+
+
+def _soap_error_message(xml_data: bytes) -> str | None:
+    """Return a user friendly SOAP error if present in the response."""
+    text = xml_data.decode("utf-8", errors="ignore")
+    if "You are not authorized to use this function" in text:
+        return (
+            "Insufficient permissions. The account number/security key/IP address "
+            "combination provided has not been granted access to the Electronic "
+            "Order API.\nSOAP exception: \"*** You are not authorized to use "
+            "this function ***\""
+        )
+    if "Illegal use of this web service" in text:
+        return (
+            "Invalid credentials. The security key provided is invalid.\nSOAP "
+            "exception: \"*** Illegal use of this web service !!! ***\""
+        )
+    return None
+
+class KeystoneSupplier(Supplier):
+    """Keystone Automotive supplier implementation."""
+    def __init__(self):
+        super().__init__('Keystone', 'keystone.json')
+
+    def configure_credentials(self) -> None:
+        """Prompt for SOAP credentials."""
+        account = input('Account Number: ')
+        key = input('Security Key: ')
+        self.set_credential('account_number', account)
+        self.set_credential('security_key', key)
+        print('Credentials saved.')
+
+    def configure_ftp(self) -> None:
+        """Prompt for FTP authentication details."""
+        user = input('FTP User: ')
+        password = input('FTP Password: ')
+        remote_dir = input('Remote Folder (optional): ')
+        remote_file = input('Remote File (optional): ')
+        self.set_credential('ftp_user', user)
+        self.set_credential('ftp_password', password)
+        if remote_dir:
+            self.set_credential('ftp_remote_dir', remote_dir)
+        if remote_file:
+            self.set_credential('remote_update_file', remote_file)
+        print('FTP credentials saved.')
+
+    # Primary method: SOAP API inventory tracking
+    def fetch_inventory_primary(self) -> bool:
+        """Retrieve incremental inventory with warehouse breakdown."""
+        account = self.get_credential('account_number')
+        key = self.get_credential('security_key')
+        output = self.get_credential('output', 'keystone_inventory_update.csv')
+        if not account or not key:
+            msg = 'Keystone credentials missing'
+            logging.warning(msg)
+            print(msg)
+            return False
+
+        envelope = f'''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ekey="http://eKeystone.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <ekey:GetInventoryUpdates>
+      <ekey:Key>{key}</ekey:Key>
+      <ekey:FullAccountNo>{account}</ekey:FullAccountNo>
+    </ekey:GetInventoryUpdates>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+
+        req = urllib.request.Request(
+            'http://order.ekeystone.com/wselectronicorder/electronicorder.asmx',
+            data=envelope.encode('utf-8'),
+            headers={
+                'Content-Type': 'text/xml; charset=utf-8',
+                'SOAPAction': 'http://eKeystone.com/GetInventoryUpdates',
+            },
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                xml_data = resp.read()
+            rows = _parse_dataset(xml_data)
+            if rows:
+                with open(output, 'w', newline='') as f:
+                    writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+                    writer.writeheader()
+                    writer.writerows(rows)
+                logging.info('Saved Keystone inventory update to %s', output)
+                return True
+            err = _soap_error_message(xml_data)
+            if err:
+                logging.warning('Keystone SOAP error: %s', err)
+                print('Error Description', err)
+            else:
+                msg = 'No data returned from Keystone update'
+                logging.warning(msg)
+                print(msg)
+        except Exception as exc:
+            logging.exception('Failed to fetch Keystone inventory: %s', exc)
+            print('Error fetching Keystone inventory via SOAP:', exc)
+        return False
+
+    # Backwards compatible alias
+    def fetch_inventory(self) -> None:
+        if not self.fetch_inventory_primary():
+            logging.info('Falling back to Keystone FTP inventory update')
+            self.fetch_inventory_secondary()
+
+    # Secondary method: FTP download
+    def fetch_inventory_secondary(self) -> None:
+        """Retrieve the inventory update file via FTP with progress output."""
+        remote_file = self.get_credential('remote_update_file')
+        if not remote_file:
+            remote_file = input('Remote file name to download: ')
+            self.set_credential('remote_update_file', remote_file)
+        remote_dir = self.get_credential('ftp_remote_dir', '')
+        remote_path = f"{remote_dir.rstrip('/')}/{remote_file}" if remote_dir else remote_file
+
+        ftp = self._ftp_connect()
+        if not ftp:
+            msg = 'Keystone FTP credentials missing or connection failed'
+            print(msg)
+            logging.warning(msg)
+            self.configure_ftp()
+            ftp = self._ftp_connect()
+            if not ftp:
+                logging.warning('Keystone FTP connection still failed')
+                return
+
+        output = self.get_credential('output', 'keystone_inventory_ftp.csv')
+        try:
+            total = ftp.size(remote_path)
+        except Exception:
+            total = None
+
+        downloaded = 0
+        try:
+            with open(output, 'wb') as f:
+                def write_chunk(data):
+                    nonlocal downloaded
+                    f.write(data)
+                    downloaded += len(data)
+                    if total:
+                        percent = int(downloaded * 100 / total)
+                        print(f"\rDownloading: {percent}%", end='', flush=True)
+                    else:
+                        kb = downloaded // 1024
+                        print(f"\rDownloaded {kb} KB", end='', flush=True)
+
+                ftp.retrbinary(f'RETR {remote_path}', write_chunk)
+            if total:
+                print('\rDownload complete      ')
+            else:
+                print(f"\rDownloaded {downloaded // 1024} KB total      ")
+            logging.info('Downloaded Keystone inventory update via FTP to %s', output)
+
+            # parse downloaded CSV into the catalog store
+            try:
+                with open(output, newline='') as f:
+                    rows = list(csv.DictReader(f))
+                if rows:
+                    catalog.save_rows(self.name, rows)
+                    logging.info('Updated %s catalog from FTP download', self.name)
+            except Exception as exc:
+                logging.warning('Failed to parse downloaded inventory: %s', exc)
+
+        except Exception as exc:
+            logging.exception('Failed to fetch Keystone FTP inventory: %s', exc)
+            print('Error downloading Keystone inventory via FTP:', exc)
+        finally:
+            try:
+                ftp.quit()
+            except Exception:
+                pass
+
+    def fetch_inventory_full(self) -> None:
+        """Retrieve the full Keystone inventory and store it as CSV."""
+        account = self.get_credential('account_number')
+        key = self.get_credential('security_key')
+        output = self.get_credential('full_output', 'keystone_inventory_full.csv')
+        if not account or not key:
+            msg = 'Keystone credentials missing'
+            logging.warning(msg)
+            print(msg)
+            return
+
+        envelope = f'''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ekey="http://eKeystone.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <ekey:GetInventoryFull>
+      <ekey:Key>{key}</ekey:Key>
+      <ekey:FullAccountNo>{account}</ekey:FullAccountNo>
+    </ekey:GetInventoryFull>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+
+        req = urllib.request.Request(
+            'http://order.ekeystone.com/wselectronicorder/electronicorder.asmx',
+            data=envelope.encode('utf-8'),
+            headers={
+                'Content-Type': 'text/xml; charset=utf-8',
+                'SOAPAction': 'http://eKeystone.com/GetInventoryFull',
+            },
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                xml_data = resp.read()
+            rows = _parse_dataset(xml_data)
+            if rows:
+                with open(output, 'w', newline='') as f:
+                    writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+                    writer.writeheader()
+                    writer.writerows(rows)
+                logging.info('Saved Keystone full inventory to %s', output)
+            else:
+                err = _soap_error_message(xml_data)
+                if err:
+                    logging.warning('Keystone SOAP error: %s', err)
+                    print('Error Description', err)
+                else:
+                    msg = 'No data returned from Keystone'
+                    logging.warning(msg)
+                    print(msg)
+        except Exception as exc:
+            logging.exception('Failed to fetch Keystone full inventory: %s', exc)
+            print('Error fetching Keystone full inventory:', exc)
+
+    def _ftp_connect(self):
+        """Connect to Keystone's implicit FTPS server."""
+        user = self.get_credential('ftp_user')
+        password = self.get_credential('ftp_password')
+        if not user or not password:
+            print('Missing FTP credentials')
+            return None
+        host = HOST
+        port = PORT
+        try:
+            import ftplib
+            ftp = ImplicitFTP_TLS()
+            ftp.connect(host, port, timeout=30)
+            try:
+                ftp.login(user, password)
+            except ftplib.error_perm as exc:
+                if '530' in str(exc):
+                    print('Login failed (530). Credentials incorrect.')
+                    return None
+                raise
+            ftp.prot_p()
+            ftp.set_pasv(True)
+            return ftp
+        except Exception as exc:
+            logging.exception('Keystone FTP connection failed: %s', exc)
+            print('Keystone FTP connection failed:', exc)
+            return None
+
+    def test_connection(self) -> None:
+        """Test SOAP and optionally FTP connectivity."""
+        ftp = self._ftp_connect()
+        if ftp:
+            ftp.quit()
+            print('FTP connection successful')
+            logging.info('Keystone FTP connection successful')
+            return
+
+        try:
+            with urllib.request.urlopen(
+                'http://order.ekeystone.com/wselectronicorder/electronicorder.asmx',
+                timeout=10,
+            ) as resp:
+                if resp.status == 200:
+                    print('Connection successful')
+                    logging.info('Keystone SOAP connection successful')
+                else:
+                    print('Connection failed: status', resp.status)
+                    logging.warning(
+                        'Keystone SOAP connection failed status %s', resp.status
+                    )
+        except Exception as exc:
+            logging.exception('Keystone SOAP connection failed: %s', exc)
+            print('Connection failed:', exc)
+
+    def fetch_catalog(self) -> None:
+        """Download the full catalog via SOAP and store it."""
+        account = self.get_credential('account_number')
+        key = self.get_credential('security_key')
+        out_dir = self.get_credential('catalog_dir', '.')
+        name = self.get_credential('catalog_name', 'keystone_catalog.xml')
+        output = os.path.join(out_dir, name)
+        if not account or not key:
+            logging.warning('Keystone credentials missing')
+            return
+        os.makedirs(out_dir, exist_ok=True)
+        envelope = f'''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ekey="http://eKeystone.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <ekey:GetInventoryQuantityFull>
+      <ekey:Key>{key}</ekey:Key>
+      <ekey:FullAccountNo>{account}</ekey:FullAccountNo>
+    </ekey:GetInventoryQuantityFull>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+        req = urllib.request.Request(
+            'http://order.ekeystone.com/wselectronicorder/electronicorder.asmx',
+            data=envelope.encode('utf-8'),
+            headers={
+                'Content-Type': 'text/xml; charset=utf-8',
+                'SOAPAction': 'http://eKeystone.com/GetInventoryQuantityFull',
+            },
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                data = resp.read()
+            with open(output, 'wb') as f:
+                f.write(data)
+            logging.info('Downloaded Keystone catalog to %s', output)
+            # placeholder parse: store minimal row
+            catalog.save_rows(self.name, [{'SKU': 'sample', 'DATA': 'see file'}])
+            print('Catalog saved to', catalog.catalog_path(self.name))
+        except Exception as exc:
+            logging.exception('Failed to fetch Keystone catalog: %s', exc)
+            print('Catalog download failed:', exc)

--- a/automation_tool/main.py
+++ b/automation_tool/main.py
@@ -1,0 +1,177 @@
+"""Console entry point for the automation tool."""
+
+import logging
+import os
+import sys
+
+# Allow running this file directly by adjusting sys.path
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from automation_tool import (
+    KeystoneSupplier,
+    CwrSupplier,
+    SeawideSupplier,
+)
+from automation_tool.scheduler import RepeatedTimer
+from automation_tool import catalog
+
+logging.basicConfig(
+    filename='automation.log',
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(message)s'
+)
+
+SUPPLIERS = {
+    '1': KeystoneSupplier(),
+    '2': CwrSupplier(),
+    '3': SeawideSupplier(),
+}
+
+# Available schedule intervals (label, seconds)
+SCHEDULES = {
+    '1': ("5 minutes", 5 * 60),
+    '2': ("1 hour", 60 * 60),
+    '3': ("1 day", 24 * 60 * 60),
+    '4': ("1 week", 7 * 24 * 60 * 60),
+}
+
+catalog_jobs = {}
+jobs = {}
+
+def schedule_function(name, func, interval, store):
+    if name in store:
+        store[name].stop()
+    timer = RepeatedTimer(interval, func)
+    timer.start()
+    store[name] = timer
+    logging.info("Scheduled %s every %s seconds", name, interval)
+
+def schedule_supplier(supplier, interval):
+    schedule_function(supplier.name, supplier.fetch_inventory, interval, jobs)
+
+def schedule_catalog(supplier, interval):
+    if hasattr(supplier, 'fetch_catalog'):
+        schedule_function(f'{supplier.name}_catalog', supplier.fetch_catalog, interval, catalog_jobs)
+
+def show_catalog_menu(supplier):
+    name = supplier.name
+    while True:
+        rows = catalog.load_rows(name)
+        print(f"\nCatalog for {name} - {len(rows)} rows")
+        print("1. Delete SKU")
+        print("2. Delete via File")
+        print("3. Back")
+        choice = input("Select option: ")
+        if choice == '1':
+            sku = input('SKU to delete: ')
+            catalog.delete_sku(name, sku)
+            print('Deleted', sku)
+        elif choice == '2':
+            path = input('Delete file path: ')
+            catalog.delete_from_file(name, path)
+            print('Processed delete file')
+        elif choice == '3':
+            break
+        else:
+            print('Invalid option')
+
+
+def show_supplier_menu(key):
+    supplier = SUPPLIERS[key]
+    while True:
+        print(f"\nSupplier: {supplier.name}")
+        opts = {}
+        idx = 1
+        print(f"{idx}. Set Credential"); opts[str(idx)] = 'cred'; idx += 1
+        if hasattr(supplier, 'configure_ftp'):
+            print(f"{idx}. Set FTP Credentials"); opts[str(idx)] = 'ftpcred'; idx += 1
+        print(f"{idx}. Fetch Inventory Update"); opts[str(idx)] = 'inv'; idx += 1
+        if hasattr(supplier, 'fetch_inventory_secondary'):
+            print(f"{idx}. Fetch Inventory Update via FTP (Secondary)"); opts[str(idx)] = 'inv_sec'; idx += 1
+        if hasattr(supplier, 'fetch_inventory_full'):
+            print(f"{idx}. Fetch Full Inventory"); opts[str(idx)] = 'inv_full'; idx += 1
+        print(f"{idx}. Schedule Inventory Update"); opts[str(idx)] = 'sch_inv'; idx += 1
+        if hasattr(supplier, 'fetch_inventory_full'):
+            print(f"{idx}. Schedule Full Inventory"); opts[str(idx)] = 'sch_inv_full'; idx += 1
+        if hasattr(supplier, 'fetch_catalog'):
+            print(f"{idx}. Fetch Catalog Now"); opts[str(idx)] = 'cat'; idx += 1
+            print(f"{idx}. Schedule Catalog"); opts[str(idx)] = 'sch_cat'; idx += 1
+            print(f"{idx}. Manage Catalog"); opts[str(idx)] = 'manage_cat'; idx += 1
+        if hasattr(supplier, 'test_connection'):
+            print(f"{idx}. Test Connection"); opts[str(idx)] = 'test'; idx += 1
+        print(f"{idx}. Back"); back_val = str(idx)
+
+        choice = input("Select option: ")
+        if choice == back_val:
+            break
+        action = opts.get(choice)
+        if action == 'cred':
+            if hasattr(supplier, 'configure_credentials'):
+                supplier.configure_credentials()
+            else:
+                k = input('Credential name: ')
+                v = input('Value: ')
+                supplier.set_credential(k, v)
+                print('Saved.')
+        elif action == 'ftpcred':
+            if hasattr(supplier, 'configure_ftp'):
+                supplier.configure_ftp()
+        elif action == 'inv':
+            supplier.fetch_inventory()
+        elif action == 'inv_full':
+            supplier.fetch_inventory_full()
+        elif action == 'inv_sec':
+            if hasattr(supplier, 'fetch_inventory_secondary'):
+                supplier.fetch_inventory_secondary()
+        elif action == 'sch_inv':
+            print("Select schedule interval:")
+            for n, (label, _) in SCHEDULES.items():
+                print(f"{n}. {label}")
+            opt = input("Choice: ")
+            if opt in SCHEDULES:
+                schedule_supplier(supplier, SCHEDULES[opt][1])
+        elif action == 'sch_inv_full':
+            if hasattr(supplier, 'fetch_inventory_full'):
+                print("Select schedule interval:")
+                for n, (label, _) in SCHEDULES.items():
+                    print(f"{n}. {label}")
+                opt = input("Choice: ")
+                if opt in SCHEDULES:
+                    schedule_function(f'{supplier.name}_full', supplier.fetch_inventory_full, SCHEDULES[opt][1], jobs)
+        elif action == 'cat':
+            supplier.fetch_catalog()
+        elif action == 'sch_cat':
+            print("Select schedule interval:")
+            for n, (label, _) in SCHEDULES.items():
+                print(f"{n}. {label}")
+            opt = input("Choice: ")
+            if opt in SCHEDULES:
+                schedule_catalog(supplier, SCHEDULES[opt][1])
+        elif action == 'manage_cat':
+            show_catalog_menu(supplier)
+        elif action == 'test':
+            supplier.test_connection()
+        else:
+            print("Invalid option")
+
+
+def main():
+    while True:
+        print("\nAutomation Tool")
+        print("1. Keystone Automotive")
+        print("2. CWR Distribution")
+        print("3. Seawide")
+        print("4. Quit")
+        choice = input("Select supplier: ")
+        if choice in SUPPLIERS:
+            show_supplier_menu(choice)
+        elif choice == '4':
+            for t in list(jobs.values()) + list(catalog_jobs.values()):
+                t.stop()
+            break
+        else:
+            print("Invalid option")
+
+if __name__ == '__main__':
+    main()

--- a/automation_tool/scheduler.py
+++ b/automation_tool/scheduler.py
@@ -1,0 +1,36 @@
+import threading
+import time
+import logging
+
+class RepeatedTimer:
+    """Run a function at a specified interval in seconds."""
+    def __init__(self, interval, function, *args, **kwargs):
+        self.interval = interval
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
+        self._timer = None
+        self.is_running = False
+
+    def _run(self):
+        self.is_running = False
+        self.start()
+        logging.info("Running scheduled task %s", self.function.__name__)
+        try:
+            self.function(*self.args, **self.kwargs)
+        except Exception as exc:
+            logging.exception("Scheduled task failed: %s", exc)
+
+    def start(self):
+        if not self.is_running:
+            logging.info("Starting timer for %s every %s seconds", self.function.__name__, self.interval)
+            self._timer = threading.Timer(self.interval, self._run)
+            self._timer.daemon = True
+            self._timer.start()
+            self.is_running = True
+
+    def stop(self):
+        if self._timer:
+            self._timer.cancel()
+        logging.info("Stopped timer for %s", self.function.__name__)
+        self.is_running = False

--- a/automation_tool/seawide.py
+++ b/automation_tool/seawide.py
@@ -1,0 +1,349 @@
+import logging
+import ftplib
+import ssl
+import os
+import csv
+import urllib.request
+import xml.etree.ElementTree as ET
+from .base import Supplier, SFTPWrapper, ImplicitFTP_TLS
+from . import catalog
+from .keystone import _parse_dataset, _soap_error_message
+
+# Fixed FTP connection details for Seawide
+HOST = "ftp.seawide.com"
+PORT = 990  # implicit FTPS
+
+class SeawideSupplier(Supplier):
+    """Seawide supplier implementation."""
+    def __init__(self):
+        super().__init__('Seawide', 'seawide.json')
+
+    def configure_credentials(self) -> None:
+        """Prompt for SOAP API credentials."""
+        account = input('Account Number: ')
+        key = input('API Key: ')
+        self.set_credential('account_number', account)
+        self.set_credential('api_key', key)
+        print('Credentials saved.')
+
+    def configure_ftp(self) -> None:
+        """Prompt for FTP access details."""
+        user = input('FTP User: ')
+        password = input('FTP Password: ')
+        remote_dir = input('Remote Folder (optional): ')
+        remote_file = input('Remote File (optional): ')
+        self.set_credential('ftp_user', user)
+        self.set_credential('ftp_password', password)
+        if remote_dir:
+            self.set_credential('ftp_remote_dir', remote_dir)
+        if remote_file:
+            self.set_credential('remote_update_file', remote_file)
+        print('FTP credentials saved.')
+
+    # Primary method: SOAP API inventory tracking
+    def fetch_inventory_primary(self) -> bool:
+        account = self.get_credential('account_number')
+        key = self.get_credential('api_key')
+        if not account or not key:
+            msg = 'Seawide API credentials missing'
+            logging.warning(msg)
+            print(msg)
+            return False
+        return self._fetch_inventory_update_soap(account, key)
+
+    # Backwards compatible alias
+    def fetch_inventory(self) -> None:
+        if not self.fetch_inventory_primary():
+            logging.info('Falling back to Seawide FTP inventory update')
+            self.fetch_inventory_secondary()
+
+    # Secondary method: FTP download
+    def fetch_inventory_secondary(self) -> None:
+        """Retrieve the inventory update file via FTP with progress output."""
+        remote_file = self.get_credential('remote_update_file')
+        if not remote_file:
+            remote_file = input('Remote file name to download: ')
+            self.set_credential('remote_update_file', remote_file)
+        remote_dir = self.get_credential('ftp_remote_dir', '')
+        remote_path = f"{remote_dir.rstrip('/')}/{remote_file}" if remote_dir else remote_file
+
+        ftp = self._ftp_connect()
+        if not ftp:
+            msg = 'Seawide FTP credentials missing or connection failed'
+            print(msg)
+            logging.warning(msg)
+            self.configure_ftp()
+            ftp = self._ftp_connect()
+            if not ftp:
+                logging.warning('Seawide FTP connection still failed')
+                return
+
+        output = self.get_credential('output', 'seawide_inventory_update.csv')
+        try:
+            try:
+                total = ftp.size(remote_path)
+            except Exception:
+                total = None
+            downloaded = 0
+            with open(output, 'wb') as f:
+                def write_chunk(data):
+                    nonlocal downloaded
+                    f.write(data)
+                    downloaded += len(data)
+                    if total:
+                        percent = int(downloaded * 100 / total)
+                        print(f"\rDownloading: {percent}%", end='', flush=True)
+                    else:
+                        kb = downloaded // 1024
+                        print(f"\rDownloaded {kb} KB", end='', flush=True)
+
+                ftp.retrbinary(f'RETR {remote_path}', write_chunk)
+            if total:
+                print('\rDownload complete      ')
+            else:
+                print(f"\rDownloaded {downloaded // 1024} KB total      ")
+            logging.info('Downloaded Seawide inventory update to %s', output)
+
+            # parse file to update catalog
+            try:
+                with open(output, newline='') as f:
+                    rows = list(csv.DictReader(f))
+                if rows:
+                    catalog.save_rows(self.name, rows)
+                    logging.info('Updated %s catalog from FTP download', self.name)
+            except Exception as exc:
+                logging.warning('Failed to parse downloaded inventory: %s', exc)
+
+        except Exception as exc:
+            logging.exception('Failed to fetch Seawide inventory: %s', exc)
+            print('Error downloading Seawide inventory via FTP:', exc)
+        finally:
+            try:
+                ftp.quit()
+            except Exception:
+                pass
+
+    def fetch_inventory_full(self) -> None:
+        """Download the full inventory file via SOAP or FTP."""
+        account = self.get_credential('account_number')
+        key = self.get_credential('api_key')
+        if account and key:
+            self._fetch_inventory_full_soap(account, key)
+            return
+
+        remote_file = self.get_credential('remote_full_file')
+        if not remote_file:
+            remote_file = input('Remote full inventory file: ')
+            self.set_credential('remote_full_file', remote_file)
+        remote_dir = self.get_credential('ftp_remote_dir', '')
+        remote_path = f"{remote_dir.rstrip('/')}/{remote_file}" if remote_dir else remote_file
+
+        ftp = self._ftp_connect()
+        if not ftp:
+            msg = 'Seawide FTP credentials missing or connection failed'
+            print(msg)
+            logging.warning(msg)
+            self.configure_ftp()
+            ftp = self._ftp_connect()
+            if not ftp:
+                logging.warning('Seawide FTP connection still failed')
+                return
+
+        output = self.get_credential('full_output', 'seawide_inventory_full.csv')
+        try:
+            with open(output, 'wb') as f:
+                ftp.retrbinary(f'RETR {remote_path}', f.write)
+            logging.info('Downloaded Seawide full inventory to %s', output)
+        except Exception as exc:
+            logging.exception('Failed to fetch Seawide full inventory: %s', exc)
+            print('Error downloading Seawide full inventory via FTP:', exc)
+        finally:
+            try:
+                ftp.quit()
+            except Exception:
+                pass
+
+    def _ftp_connect(self):
+        """Connect to Seawide's implicit FTPS server."""
+        user = self.get_credential('ftp_user')
+        password = self.get_credential('ftp_password')
+        if not user or not password:
+            print('Missing FTP credentials')
+            return None
+        host = HOST
+        port = PORT
+        try:
+            ftp = ImplicitFTP_TLS()
+            ftp.connect(host, port, timeout=30)
+            try:
+                ftp.login(user, password)
+            except ftplib.error_perm as exc:
+                if '530' in str(exc):
+                    print('Login failed (530). Credentials incorrect.')
+                    return None
+                raise
+            ftp.prot_p()
+            ftp.set_pasv(True)
+            return ftp
+        except Exception as exc:
+            logging.exception('Seawide FTP connection failed: %s', exc)
+            print('Seawide FTP connection failed:', exc)
+            return None
+
+    def _fetch_inventory_update_soap(self, account: str, key: str) -> bool:
+        """Retrieve inventory updates via SOAP."""
+        output = self.get_credential('output', 'seawide_inventory_update.csv')
+        envelope = f'''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sea="http://seawide.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <sea:GetInventoryUpdates>
+      <sea:Key>{key}</sea:Key>
+      <sea:FullAccountNo>{account}</sea:FullAccountNo>
+    </sea:GetInventoryUpdates>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+        req = urllib.request.Request(
+            'https://api.seawide.com/inventory.asmx',
+            data=envelope.encode('utf-8'),
+            headers={'Content-Type': 'text/xml; charset=utf-8',
+                    'SOAPAction': 'http://seawide.com/GetInventoryUpdates'},
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                xml_data = resp.read()
+            rows = _parse_dataset(xml_data)
+            if rows:
+                with open(output, 'w', newline='') as f:
+                    writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+                    writer.writeheader()
+                    writer.writerows(rows)
+                logging.info('Saved Seawide inventory update to %s', output)
+                return True
+            err = _soap_error_message(xml_data)
+            if err:
+                logging.warning('Seawide SOAP error: %s', err)
+                print('Error Description', err)
+            else:
+                msg = 'No data returned from Seawide update'
+                logging.warning(msg)
+                print(msg)
+        except Exception as exc:
+            logging.exception('Failed to fetch Seawide SOAP update: %s', exc)
+            print('Error fetching Seawide inventory via SOAP:', exc)
+        return False
+
+    def _fetch_inventory_full_soap(self, account: str, key: str) -> None:
+        """Retrieve full inventory via SOAP."""
+        output = self.get_credential('full_output', 'seawide_inventory_full.csv')
+        envelope = f'''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sea="http://seawide.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <sea:GetInventoryFull>
+      <sea:Key>{key}</sea:Key>
+      <sea:FullAccountNo>{account}</sea:FullAccountNo>
+    </sea:GetInventoryFull>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+        req = urllib.request.Request(
+            'https://api.seawide.com/inventory.asmx',
+            data=envelope.encode('utf-8'),
+            headers={'Content-Type': 'text/xml; charset=utf-8',
+                    'SOAPAction': 'http://seawide.com/GetInventoryFull'},
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                xml_data = resp.read()
+            rows = _parse_dataset(xml_data)
+            if rows:
+                with open(output, 'w', newline='') as f:
+                    writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+                    writer.writeheader()
+                    writer.writerows(rows)
+                logging.info('Saved Seawide full inventory to %s', output)
+            else:
+                err = _soap_error_message(xml_data)
+                if err:
+                    logging.warning('Seawide SOAP error: %s', err)
+                    print('Error Description', err)
+                else:
+                    msg = 'No data returned from Seawide full inventory'
+                    logging.warning(msg)
+                    print(msg)
+        except Exception as exc:
+            logging.exception('Failed to fetch Seawide SOAP full inventory: %s', exc)
+            print('Error fetching Seawide full inventory via SOAP:', exc)
+
+    def test_connection(self) -> None:
+        """Attempt to connect to FTP first, then SOAP."""
+        ftp = self._ftp_connect()
+        if ftp:
+            ftp.quit()
+            print('FTP connection successful')
+            logging.info('Seawide FTP connection successful')
+            return
+
+        account = self.get_credential('account_number')
+        key = self.get_credential('api_key')
+        if account and key:
+            envelope = f'''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sea="http://seawide.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <sea:GetInventoryUpdates>
+      <sea:Key>{key}</sea:Key>
+      <sea:FullAccountNo>{account}</sea:FullAccountNo>
+    </sea:GetInventoryUpdates>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+            req = urllib.request.Request(
+                'https://api.seawide.com/inventory.asmx',
+                data=envelope.encode('utf-8'),
+                headers={'Content-Type': 'text/xml; charset=utf-8',
+                        'SOAPAction': 'http://seawide.com/GetInventoryUpdates'},
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    if resp.status == 200:
+                        print('Connection successful')
+                        logging.info('Seawide SOAP connection successful')
+                        return
+                    print('Connection failed: status', resp.status)
+                    logging.warning('Seawide SOAP connection failed %s', resp.status)
+                    return
+            except Exception as exc:
+                logging.exception('Seawide SOAP connection failed: %s', exc)
+                print('Connection failed:', exc)
+        else:
+            print('Missing credentials')
+
+    def fetch_catalog(self) -> None:
+        """Download the vendor catalog from FTP."""
+        remote = self.get_credential('catalog_remote', 'catalog.csv')
+        out_dir = self.get_credential('catalog_dir', '.')
+        name = self.get_credential('catalog_name', 'seawide_catalog.csv')
+        mapping_file = self.get_credential('mapping_file')
+        output = os.path.join(out_dir, name)
+
+        ftp = self._ftp_connect()
+        if not ftp:
+            logging.warning('Seawide FTP credentials missing')
+            print('Missing credentials')
+            return
+
+        os.makedirs(out_dir, exist_ok=True)
+        try:
+            with open(output, 'wb') as f:
+                ftp.retrbinary(f'RETR {remote}', f.write)
+            logging.info('Downloaded Seawide catalog to %s', output)
+            with open(output, newline='') as f:
+                rows = list(csv.DictReader(f))
+            rows = catalog.apply_mapping(rows, mapping_file)
+            catalog.save_rows(self.name, rows)
+            print('Catalog saved to', catalog.catalog_path(self.name))
+        except Exception as exc:
+            logging.exception('Failed to fetch Seawide catalog: %s', exc)
+            print('Catalog download failed:', exc)
+        finally:
+            try:
+                ftp.quit()
+            except Exception:
+                pass

--- a/inventory_processor.py
+++ b/inventory_processor.py
@@ -1,0 +1,64 @@
+"""Download and merge CWR Distribution inventory feed."""
+
+import csv
+import json
+import ssl
+import urllib.request
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def download_inventory(base_url: str, since: int) -> list:
+    """Download CSV data from CWR."""
+    url = f"{base_url}&ohtime={since}"
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    with urllib.request.urlopen(url, context=context) as resp:
+        return list(csv.DictReader(
+            (line.decode('utf-8') for line in resp),
+            fieldnames=["SKU", "Quantity", "UPC/EAN", "Manufacturer", "Price", "MAP", "MRP", "qtynj", "qtyfl"]
+        ))
+
+
+def merge_mapping(rows: list, mapping_path: Path) -> list:
+    with open(mapping_path, newline='') as f:
+        mapping = {r['sku']: r['modified_sku'] for r in csv.DictReader(f)}
+    merged = []
+    for r in rows:
+        sku = r['SKU']
+        if sku in mapping:
+            merged.append({
+                'SKU': mapping[sku],
+                'Quantity': r['Quantity'],
+                'qtynj': r.get('qtynj', 0),
+                'qtyfl': r.get('qtyfl', 0),
+                'handling-time': 0,
+            })
+    return merged
+
+
+def save_inventory(rows: list, output: Path):
+    with open(output, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['SKU', 'Quantity', 'qtynj', 'qtyfl', 'handling-time'], delimiter='\t')
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+
+
+def main(base_url: str, since: int, mapping: Path, output: Path):
+    rows = download_inventory(base_url, since)
+    merged = merge_mapping(rows, mapping)
+    save_inventory(merged, output)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process CWR inventory feed")
+    parser.add_argument('--base-url', required=True, help='Feed base URL')
+    parser.add_argument('--since', type=int, help='UNIX timestamp', default=int((datetime.now() - timedelta(hours=10)).timestamp()))
+    parser.add_argument('--mapping', required=True, type=Path)
+    parser.add_argument('--output', required=True, type=Path)
+    args = parser.parse_args()
+    main(args.base_url, args.since, args.mapping, args.output)


### PR DESCRIPTION
## Summary
- adjust `automation_tool.main` so it works when executed as a script
- enable passive mode for Seawide FTP connections
- enable passive mode on FTP connections
- align Seawide FTP config and defaults with Keystone
- ensure FTP sessions use passive mode without extra attributes
- improve TLS handshake when connecting via implicit FTPS
- log SOAP permission errors for Keystone and Seawide
- add `ImplicitFTP_TLS` helper for better implicit FTPS
- use `ImplicitFTP_TLS` in Keystone and Seawide
- parse downloaded FTP inventory files into the catalog
- simplify FTP credential prompts
- use fixed FTP hosts
- show download progress even without file size
- improve implicit FTPS connection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860481c5afc832982801b485890d884